### PR TITLE
Accessibility polling updates

### DIFF
--- a/web/assets/javascripts/dashboard-charts.js
+++ b/web/assets/javascripts/dashboard-charts.js
@@ -83,6 +83,8 @@ class RealtimeChart extends DashboardChart {
     this.chart.data.datasets[1].data.push(failed);
     this.chart.update();
 
+    updateScreenReaderDashboardValues(processed, failed);
+
     updateStatsSummary(this.stats.sidekiq);
     updateRedisStats(this.stats.redis);
     updateFooterUTCTime(this.stats.server_utc_time);

--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -36,6 +36,12 @@ var ready = (callback) => {
   else document.addEventListener("DOMContentLoaded", callback);
 }
 
+var updateScreenReaderDashboardValues = function(processed, failed) {
+  let lastDashboardUpdateSpan = document.getElementById("sr-last-dashboard-update");
+  var updateText = document.getElementById("sr-last-dashboard-update-template").innerText;
+  lastDashboardUpdateSpan.innerText = updateText.replace("PROCESSED_COUNT", processed).replace("FAILED_COUNT", failed);
+}
+
 ready(() => {
   var sldr = document.getElementById('sldr');
   if (typeof localStorage.sidekiqTimeInterval !== 'undefined') {

--- a/web/assets/stylesheets/style.css
+++ b/web/assets/stylesheets/style.css
@@ -35,6 +35,20 @@
   outline: 1px solid oklch(from var(--color-primary) l c h / 50%);
 }
 
+.sr-only {
+  border: 0 !important;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  -webkit-clip-path: inset(50%) !important;
+  clip-path: inset(50%) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+  white-space: nowrap !important;
+}
+
 html {
   font-family: var(--font-sans);
   font-size: var(--font-size);

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -36,6 +36,7 @@ en:
   Kill: Kill
   KillAll: Kill All
   Language: Language
+  LastDashboardUpdateTemplateLiteral: "Latest poll: Processed: PROCESSED_COUNT. Failed: FAILED_COUNT."
   LastRetry: Last Retry
   Latency: Latency
   LivePoll: Live Poll

--- a/web/views/dashboard.erb
+++ b/web/views/dashboard.erb
@@ -4,7 +4,7 @@
   <header>
     <h1>
       <%= t('Dashboard') %>
-      <span id="beacon" class="beacon" aria-hidden="true"></span>
+      <span id="beacon" class="beacon"></span>
     </h1>
     <div class="filter interval-slider">
       <span class="interval-slider-label"><%= t('PollingInterval') %>:</span>

--- a/web/views/dashboard.erb
+++ b/web/views/dashboard.erb
@@ -4,7 +4,7 @@
   <header>
     <h1>
       <%= t('Dashboard') %>
-      <span id="beacon" class="beacon" aria-label="<%= t("LivePoll") %>" role="status"></span>
+      <span id="beacon" class="beacon" aria-hidden="true"></span>
     </h1>
     <div class="filter interval-slider">
       <span class="interval-slider-label"><%= t('PollingInterval') %>:</span>
@@ -15,6 +15,9 @@
   </header>
 
   <div class="chart">
+    <span id="sr-last-dashboard-update-template" hidden="hidden"><%= t("LastDashboardUpdateTemplateLiteral") %></span>
+    <span id="sr-last-dashboard-update" class="sr-only" role="status"></span>
+
     <canvas id="realtime-chart">
       <%= to_json({
         processedLabel: t('Processed'),


### PR DESCRIPTION
When there is an update in the dashboard, if the user is using a screen reader, they should be informed about the update.

This PR makes it so the screen reader will say "Latest poll: Processed: 16. Failed: 0." each update if there is a change (by default polling happens every 5 seconds, but this can be changed between 2 and 20 seconds).

This works thanks to the `role="status"` attribute. The text will only be read when the user is idle, it will not interrupt other activity.